### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.3",
   "description": "MediaScanner should be called to add a downloaded image to Android Gallery.",
   "cordova": {
-    "id": "br.com.brunogrossi.MediaScannerPlugin",
+    "id": "cordova-plugin-mediascanner",
     "platforms": [
       "android"
     ]


### PR DESCRIPTION
Set correct package id in package.json - This should fix an error ("Failed to restore plugin br.com.brunogrossi.MediaScannerPlugin from config.xml") in restoring the plugin by "cordova prepare" command.